### PR TITLE
NUnit test fixes

### DIFF
--- a/Backend/Source/Battleship.Domain.Tests/FleetTests.cs
+++ b/Backend/Source/Battleship.Domain.Tests/FleetTests.cs
@@ -371,7 +371,7 @@ namespace Battleship.Domain.Tests
                 "You must use the TryMoveShipTo method to position each ship on the grid.");
 
             var numberOfWhileLoops = method.Body
-                .DescendantNodes().Count(node => node is WhileStatementSyntax);
+                .DescendantNodes().Count(node => node is WhileStatementSyntax || node is DoStatementSyntax);
 
             Assert.That(numberOfWhileLoops, Is.EqualTo(1),
                 "You must use exactly one while loop. For each ship you must try to move it onto the grid until it succeeds.");

--- a/Backend/Source/Battleship.Domain.Tests/FleetTests.cs
+++ b/Backend/Source/Battleship.Domain.Tests/FleetTests.cs
@@ -272,15 +272,15 @@ namespace Battleship.Domain.Tests
             //Arrange
             IShip shipToMove = _internalDictionary.Values.NextRandomElement();
 
-            GridCoordinate[] targetCoordinates = CreateAlignedAndLinkedGridCoordinates(shipToMove.Kind.Size, out bool horizontal);
-
-            int invalidCoordinateIndex = RandomGenerator.Next(0, shipToMove.Kind.Size);
+            GridCoordinate[] targetCoordinates = CreateAlignedAndLinkedGridCoordinates(shipToMove.Kind.Size, out bool horizontal)
+                                                    .OrderByDescending(c => horizontal ? c.Column : c.Row)
+                                                    .ToArray();
             int gridSize = _gridMock.Object.Size;
 
             //break the link
-            int row = horizontal ? targetCoordinates[invalidCoordinateIndex].Row : (targetCoordinates.Max(c => c.Row) + 1) % gridSize;
-            int column = horizontal ? (targetCoordinates.Max(c => c.Column) + 1) % gridSize : targetCoordinates[invalidCoordinateIndex].Column;
-            targetCoordinates[invalidCoordinateIndex] = new GridCoordinate(row, column);
+            int row = horizontal ? targetCoordinates[0].Row : (targetCoordinates.Max(c => c.Row) + 1) % gridSize;
+            int column = horizontal ? (targetCoordinates.Max(c => c.Column) + 1) % gridSize : targetCoordinates[0].Column;
+            targetCoordinates[0] = new GridCoordinate(row, column);
 
             //Act
             Result result = _fleet.TryMoveShipTo(shipToMove.Kind, targetCoordinates, _gridMock.Object);

--- a/Backend/Source/Battleship.Domain.Tests/FleetTests.cs
+++ b/Backend/Source/Battleship.Domain.Tests/FleetTests.cs
@@ -272,15 +272,15 @@ namespace Battleship.Domain.Tests
             //Arrange
             IShip shipToMove = _internalDictionary.Values.NextRandomElement();
 
-            GridCoordinate[] targetCoordinates = CreateAlignedAndLinkedGridCoordinates(shipToMove.Kind.Size, out bool horizontal)
-                                                    .OrderByDescending(c => horizontal ? c.Column : c.Row)
-                                                    .ToArray();
+            GridCoordinate[] targetCoordinates = CreateAlignedAndLinkedGridCoordinates(shipToMove.Kind.Size, out bool horizontal);
+
+            int invalidCoordinateIndex = RandomGenerator.Next(1, shipToMove.Kind.Size);
             int gridSize = _gridMock.Object.Size;
 
             //break the link
-            int row = horizontal ? targetCoordinates[0].Row : (targetCoordinates.Max(c => c.Row) + 1) % gridSize;
-            int column = horizontal ? (targetCoordinates.Max(c => c.Column) + 1) % gridSize : targetCoordinates[0].Column;
-            targetCoordinates[0] = new GridCoordinate(row, column);
+            int row = horizontal ? targetCoordinates[invalidCoordinateIndex].Row : (targetCoordinates.Max(c => c.Row) + 1) % gridSize;
+            int column = horizontal ? (targetCoordinates.Max(c => c.Column) + 1) % gridSize : targetCoordinates[invalidCoordinateIndex].Column;
+            targetCoordinates[invalidCoordinateIndex] = new GridCoordinate(row, column);
 
             //Act
             Result result = _fleet.TryMoveShipTo(shipToMove.Kind, targetCoordinates, _gridMock.Object);


### PR DESCRIPTION
Currently the TryMoveShipTo_ShouldFailWhenTheSegmentCoordinatesAreNotLinked test fails when it's attempting to change the lowest value of a 2-sized boat, for instance:
{2, 0}
{3, 0}

When the RandomGenerator results in a 0, the first coordinate will be changed to {4, 0} if it's vertical. The coordinates will then become:
{4, 0}
{3, 0}

The link will still work and the test will fail.

As for the second change: I'm currently using a do statement to remove the need for double code, which may or may not be seen as bad practice, but should be allowed and valid to be criticized through the resulting points score.